### PR TITLE
updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "phergie/phergie-irc-bot-react": "1.*"
+        "phergie/phergie-irc-bot-react": "~1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",


### PR DESCRIPTION
Not 100% sure why but the 1.\* started causing issues when bot was tagged 1.0

Updated to ~1 in line with other plugins and all now seems to work again
