### PR TITLE
added auto-rejoin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ return array(
             // the NickServ plugin has successfully logged in
             'wait-for-nickserv' => true,
 
+            // Optional: if true, joins all channels in 'channels' config
+            // Defaults to false, and don't rejoin automatically
+            'auto-rejoin' => true,
+            // or
+            'auto-rejoin' => '#channel1,#channel2',
+            // or
+            'auto-rejoin' => array('#channel1', '#channel2'),
+
         )),
 
         // If wait-for-nickserv is enabled, the NickServ plugin must also be used

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,7 @@ namespace Phergie\Irc\Plugin\React\AutoJoin;
 
 use Phergie\Irc\Bot\React\AbstractPlugin;
 use Phergie\Irc\Bot\React\EventQueueInterface;
-use Phergie\Irc\Event\EventInterface;
+use Phergie\Irc\Event\UserEventInterface;
 
 /**
  * Plugin for automatically joining channels.
@@ -43,6 +43,20 @@ class Plugin extends AbstractPlugin
      * @var bool
      */
     protected $awaitNickServ = false;
+
+    /**
+     * Array list of channels to rejoin
+     *
+     * @var array
+     */
+    protected $rejoinChannels = false;
+
+    /**
+     * Array list of channels to rejoin
+     *
+     * @var array
+     */
+    protected $rejoinKeys = array();
 
     /**
      * Accepts plugin configuration.
@@ -79,6 +93,32 @@ class Plugin extends AbstractPlugin
         if (!empty($config['wait-for-nickserv'])) {
             $this->awaitNickServ = true;
         }
+
+        if (isset($config['auto-rejoin'])) {
+            if ($config['auto-rejoin'] === true) {
+                $this->rejoinChannels = explode(',', $this->channels);
+            } elseif (is_string($config['auto-rejoin'])) {
+                $this->rejoinChannels = explode(',', $config['auto-rejoin']);
+            } elseif (is_array($config['auto-rejoin'])) {
+                $this->rejoinChannels = $config['auto-rejoin'];
+            } else {
+                throw new \InvalidArgumentException('"auto-rejoin" must be '.
+                    'boolean, string or array');
+            }
+
+            if ($this->keys != null) {
+                $channels = explode(',', $this->channels);
+                $keys = explode(',', $this->keys);
+                foreach ($this->rejoinChannels as $key => $value) {
+                    $index = array_search($value, $channels);
+                    $this->rejoinKeys[$key] = $index !== false
+                        ? $keys[$index] : null;
+                }
+            } else {
+                $this->rejoinKeys = array_fill(0,
+                    count($this->rejoinChannels), null);
+            }
+        }
     }
 
     /**
@@ -92,13 +132,21 @@ class Plugin extends AbstractPlugin
      */
     public function getSubscribedEvents()
     {
-        return $this->awaitNickServ
-            ? array(
-                'nickserv.identified' => 'joinChannels',
-            )
-            : array(
-                'irc.received.rpl_endofmotd' => 'joinChannels',
-                'irc.received.err_nomotd' => 'joinChannels',
+        return array_merge(
+            $this->awaitNickServ
+                ? array(
+                    'nickserv.identified' => 'joinChannels',
+                )
+                : array(
+                    'irc.received.rpl_endofmotd' => 'joinChannels',
+                    'irc.received.err_nomotd' => 'joinChannels',
+                ),
+            $this->rejoinChannels
+                ? array(
+                    'irc.received.part' => 'onPartChannels',
+                    'irc.received.kick' => 'onKickChannels',
+                )
+                : array()
             );
     }
 
@@ -112,5 +160,37 @@ class Plugin extends AbstractPlugin
     public function joinChannels($dummy, EventQueueInterface $queue)
     {
         $queue->ircJoin($this->channels, $this->keys);
+    }
+
+    /**
+     * Rejoins a channel in provided list of channels on a part event.
+     *
+     * @param \Phergie\Irc\Event\UserEventInterface $event
+     * @param \Phergie\Irc\Bot\React\EventQueueInterface $queue
+     */
+    public function onPartChannels(UserEventInterface $event, EventQueueInterface $queue)
+    {
+        if ($event->getNick() == $event->getConnection()->getNickname()
+            && in_array($event->getSource(), $this->rejoinChannels)) {
+            $index = array_search($event->getSource(), $this->rejoinChannels);
+            $queue->ircJoin($this->rejoinChannels[$index],
+                $this->rejoinKeys[$index]);
+        }
+    }
+
+    /**
+     * Rejoins a channel in provided list of channels on a kick event.
+     *
+     * @param \Phergie\Irc\Event\UserEventInterface $event
+     * @param \Phergie\Irc\Bot\React\EventQueueInterface $queue
+     */
+    public function onKickChannels(UserEventInterface $event, EventQueueInterface $queue)
+    {
+        if ($event->getParams()['user'] == $event->getConnection()->getNickname()
+            && in_array($event->getSource(), $this->rejoinChannels)) {
+            $index = array_search($event->getSource(), $this->rejoinChannels);
+            $queue->ircJoin($this->rejoinChannels[$index],
+                $this->rejoinKeys[$index]);
+        }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,7 +52,7 @@ class Plugin extends AbstractPlugin
     protected $rejoinChannels = false;
 
     /**
-     * Array list of channels to rejoin
+     * Array list of channels keys to rejoin
      *
      * @var array
      */
@@ -71,6 +71,10 @@ class Plugin extends AbstractPlugin
      *
      * wait-for-nickserv - optional, set to true to wait for the NickServ plugin
      * to successfully authenticate before joining channels
+     *
+     * auto-rejoin - optional, set to true to rejoin all channels in 'channels'
+     * option, or set a comma-delimited string or array of names of channels to
+     * rejoin only in these channels.
      *
      * @param array $config
      */
@@ -94,7 +98,7 @@ class Plugin extends AbstractPlugin
             $this->awaitNickServ = true;
         }
 
-        if (isset($config['auto-rejoin'])) {
+        if (isset($config['auto-rejoin']) && $config['auto-rejoin']) {
             if ($config['auto-rejoin'] === true) {
                 $this->rejoinChannels = explode(',', $this->channels);
             } elseif (is_string($config['auto-rejoin'])) {
@@ -127,6 +131,7 @@ class Plugin extends AbstractPlugin
      * - an end or lack of a message of the day,
      * at which point the client should be authenticated and
      * in a position to join channels.
+     * If auto-rejoin is set the plugin also monitors part and kick events.
      *
      * @return array
      */


### PR DESCRIPTION
Adds an extra option allowing rejoin when a kick or part event is received.

```php
        new \Phergie\Irc\Plugin\React\AutoJoin\Plugin(array(
            // if true, rejoins all channels in 'channels' config
            'auto-rejoin' => true,
            // if string, rejoins all comma separated channels
            'auto-rejoin' => '#channel1,#channel2',
            // if array, rejoins all channels in array
            'auto-rejoin' => array('#channel1', '#channel2'),
        )),
```